### PR TITLE
feat: Add ash-project-gen and ash-gen-resource fish scripts

### DIFF
--- a/script/ash-gen-resource.fish
+++ b/script/ash-gen-resource.fish
@@ -1,0 +1,34 @@
+function ash-gen-resource
+    argparse --name=ash-gen-resource 'a/attribute=+' 'r/relationship=+' -- $argv
+    or return
+
+    if test (count $argv) -ne 1
+        echo "Error: resource name is required"
+        echo "Usage: ash-gen-resource resource_name [options]"
+        return 1
+    end
+
+    set resource_name (string trim $argv[1])
+
+    set command "mix ash.gen.resource $resource_name --uuid-primary-key id --default-actions update,read,update,destroy"
+
+    # Add attributes
+    if set -q _flag_attribute
+        for attr in $_flag_attribute
+            set command "$command --attribute $attr "
+        end
+    end
+
+    # Add relationships
+    if set -q _flag_relationship
+        for rel in $_flag_relationship
+            set command "$command --relationship $rel "
+        end
+    end
+
+    # Add timestamps and extensions
+    set command "$command --timestamps --extend postgres --yes"
+
+    echo -e $command
+    eval $command
+end

--- a/script/ash-gen-resource.md
+++ b/script/ash-gen-resource.md
@@ -1,0 +1,67 @@
+# Ash Gen Resource
+
+This Fish shell function simplifies the process of generating Ash resources using the `mix ash.gen.resource` command with common defaults and simplified option handling.
+
+## Overview
+
+The `ash-gen-resource` function generates an Ash resource with:
+
+- UUID primary key (`id` attribute)
+- Default CRUD actions (create, read, update, destroy)
+- Timestamps
+- Extended with postgres support
+- Auto-confirmation (--yes)
+
+## Usage
+
+```fish
+ash-gen-resource resource_name [options]
+```
+
+### Options
+
+- `-a` or `--attribute`: Add an attribute to the resource
+
+  - Format: `name:type[:modifier1][:modifier2]...`
+  - Available modifiers: `primary_key`, `public`, `sensitive`, `required`
+
+- `-r` or `--relationship`: Add a relationship to the resource
+  - Format: `type:name:destination[:modifier1][:modifier2]...`
+  - Available modifiers: `public`
+  - For `belongs_to` relationships, additional modifiers: `primary_key`, `sensitive`, `required`
+
+## Examples
+
+### Basic resource with attributes
+
+```fish
+ash-gen-resource MyApp.Blog.Post \
+  -a title:string:required:public \
+  -a body:text:public \
+  -a view_count:integer
+```
+
+### Resource with relationships
+
+```fish
+ash-gen-resource MyApp.Blog.Comment \
+  -a content:text:required:public \
+  -r belongs_to:post:MyApp.Blog.Post:required \
+  -r belongs_to:author:MyApp.Accounts.User
+```
+
+### Complex example
+
+```fish
+ash-gen-resource Helpdesk.Support.Ticket \
+  -a subject:string:required:public \
+  -a body:string:public \
+  -a status:string:public \
+  -a priority:integer:public \
+  -r belongs_to:representative:Helpdesk.Support.Representative \
+  -r belongs_to:customer:Helpdesk.Accounts.Customer:required
+```
+
+## Generated Command
+
+The function will print the generated `mix ash.gen.resource` command before executing it, allowing you to see exactly what will be run.

--- a/script/ash-project-gen.fish
+++ b/script/ash-project-gen.fish
@@ -1,0 +1,54 @@
+function ash-project-gen -d "Generate an Ash Framework project"
+    # Parse arguments
+    argparse 'i/igniter=+' -- $argv
+    or return 1
+
+    # Get project name from positional argument
+    if set -q argv[1]
+        set project_name $argv[1]
+    else
+        set project_name "ash_demo_project"
+    end
+
+    # Set default igniter arguments to match the original script
+    # Define default packages to install if no igniter arguments provided
+    if not set -q _flag_igniter
+        set _flag_igniter \
+            "ash_phoenix" \
+            "ash_json_api" \
+            "ash_postgres" \
+            "ash_authentication" \
+            "ash_authentication_phoenix" \
+            "ash_admin" \
+            "ash_oban" \
+            "ash_state_machine" \
+            "ash_paper_trail" \
+            "--auth-strategy" "password" \
+            "--auth-strategy" "magic_link" \
+            "--yes"
+    end
+
+    # Install base project
+    sh -c "curl -s 'https://ash-hq.org/new/$project_name?install=phoenix' | sh"
+
+    if test $status -eq 0
+        # Change to project directory
+        cd $project_name
+
+        # Install igniter packages with arguments
+        set igniter_cmd "mix igniter.install $_flag_igniter"
+        eval $igniter_cmd
+
+        # Setup ash
+        if test $status -eq 0
+            mix ash.setup
+            return $status
+        else
+            echo "Failed to install igniter packages"
+            return 1
+        end
+    else
+        echo "Failed to create project"
+        return 1
+    end
+end


### PR DESCRIPTION
This pull request introduces new Fish shell functions to simplify the generation of Ash Framework resources and projects. The primary changes include the addition of the `ash-gen-resource` and `ash-project-gen` functions, along with their corresponding documentation.

### New Fish shell functions:

* [`script/ash-gen-resource.fish`](diffhunk://#diff-a50cb32d1c0f7e052013be526c1d9932a604c0ba86134c46ad2f0283a7ef3b47R1-R34): Added the `ash-gen-resource` function to generate Ash resources with common defaults and simplified option handling. The function supports adding attributes and relationships to the resource.

* [`script/ash-project-gen.fish`](diffhunk://#diff-ea17a5ef4dcb14021b6773b320653e74c2fa1967e9b9156e7c2d90afac571639R1-R54): Added the `ash-project-gen` function to generate a new Ash Framework project with default packages and configuration. The function allows specifying additional igniter packages.

### Documentation:

* [`script/ash-gen-resource.md`](diffhunk://#diff-e4ddb3a50f3d91520847386d17c3f4e147cb7800efd57fc26be6938b684e5caaR1-R67): Added documentation for the `ash-gen-resource` function, including an overview, usage instructions, options, examples, and details about the generated command.